### PR TITLE
Change gradle build file to run code coverage report. 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: "jacoco"
 
 android {
 
@@ -36,6 +37,7 @@ android {
     lintOptions {
         abortOnError false
     }
+
 }
 
 dependencies {

--- a/runCoverageReport.bat
+++ b/runCoverageReport.bat
@@ -1,0 +1,1 @@
+gradlew createDebugCoverageReport


### PR DESCRIPTION
Change gradle build file to run code coverage report. 

At terminal/cmd.exe, type "runCoverageReport" to directly generate the report.
