### PR TITLE
Time re-phase, Apps rename, Replies sort

### DIFF
--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/QuestionListAdapter.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/QuestionListAdapter.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.text.Html;
+import android.text.format.DateUtils;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -62,15 +63,10 @@ public class QuestionListAdapter extends FirebaseListAdapter<Question> {
         int like = question.getLike();
         int dislike = question.getDislike();
 
-//<<<<<<< HEAD
         ImageButton likeButton = (ImageButton) view.findViewById(R.id.QuestionLike);
         ImageButton dislikeButton = (ImageButton) view.findViewById(R.id.QuestionDislike);
         ImageButton replyButton = (ImageButton) view.findViewById(R.id.QuestionReply);
-/*=======
-        ImageButton likeButton = (ImageButton) view.findViewById(R.id.QuestionLike);
-        ImageButton dislikeButton = (ImageButton) view.findViewById(R.id.QuestionDislike);
-        ImageButton replyButton = (ImageButton) view.findViewById(R.id.QuestionReply);
->>>>>>> refs/remotes/origin/master*/
+
         TextView timeText = (TextView) view.findViewById((R.id.timetext));
         TextView likeNumText = (TextView) view.findViewById((R.id.likenumber));
         TextView dislikeNumText = (TextView) view.findViewById((R.id.dislikenumber));
@@ -155,11 +151,28 @@ public class QuestionListAdapter extends FirebaseListAdapter<Question> {
         return roomName;
     }
 
-    private String getDate(long timestamp)
+    //If you want to know more about the function, plz visit here http://developer.android.com/reference/android/text/format/DateUtils.html
+    private String getDate(long postTime)
     {
-        DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        Date date = (new Date(timestamp));
-        return df.format(date);
+        long currentTime = new Date().getTime();
+        long timeResolution = 0;
+        long timeDiff = currentTime-postTime;
+        if(timeDiff < DateUtils.SECOND_IN_MILLIS*5){
+            return "Just now";
+        }
+
+        if(timeDiff/DateUtils.MINUTE_IN_MILLIS == 0){
+            timeResolution = DateUtils.SECOND_IN_MILLIS;
+        }else if(timeDiff/DateUtils.HOUR_IN_MILLIS == 0){
+            timeResolution = DateUtils.MINUTE_IN_MILLIS;
+        }else if(timeDiff/DateUtils.DAY_IN_MILLIS == 0){
+            timeResolution = DateUtils.HOUR_IN_MILLIS;
+        }else{
+            DateFormat df = new SimpleDateFormat("dd/MM/yyyy KK:mm aa");
+            Date date = (new Date(postTime));
+            return df.format(date);
+        }
+        return DateUtils.getRelativeTimeSpanString(postTime, currentTime, timeResolution).toString();
     }
     @Override
     protected void sortModels(List<Question> mModels) {

--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/QuestionListAdapter.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/QuestionListAdapter.java
@@ -168,7 +168,7 @@ public class QuestionListAdapter extends FirebaseListAdapter<Question> {
         }else if(timeDiff/DateUtils.DAY_IN_MILLIS == 0){
             timeResolution = DateUtils.HOUR_IN_MILLIS;
         }else{
-            DateFormat df = new SimpleDateFormat("dd/MM/yyyy KK:mm aa");
+            DateFormat df = new SimpleDateFormat("yyyy/MM/dd KK:mm aa");
             Date date = (new Date(postTime));
             return df.format(date);
         }

--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyActivity.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyActivity.java
@@ -374,7 +374,7 @@ public class ReplyActivity extends ListActivity {
         }else if(timeDiff/DateUtils.DAY_IN_MILLIS == 0){
             timeResolution = DateUtils.HOUR_IN_MILLIS;
         }else{
-            DateFormat df = new SimpleDateFormat("dd/MM/yyyy KK:mm aa");
+            DateFormat df = new SimpleDateFormat("yyyy/MM/dd KK:mm aa");
             Date date = (new Date(postTime));
             return df.format(date);
         }

--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyActivity.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyActivity.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -37,6 +38,7 @@ import hk.ust.cse.hunkim.questionroom.reply.Reply;
  */
 public class ReplyActivity extends ListActivity {
     private static final String FIREBASE_URL = "https://cmkquestionsdb.firebaseio.com/";
+
 
     private String key;
     private String roomName;
@@ -355,12 +357,30 @@ public class ReplyActivity extends ListActivity {
         );
     }
 
-    private String getDate(long timestamp)
+    //If you want to know more about the function, plz visit here http://developer.android.com/reference/android/text/format/DateUtils.html
+    private String getDate(long postTime)
     {
-        DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        Date date = (new Date(timestamp));
-        return df.format(date);
+        long currentTime = new Date().getTime();
+        long timeResolution = 0;
+        long timeDiff = currentTime-postTime;
+        if(timeDiff < DateUtils.SECOND_IN_MILLIS*5){
+            return "Just now";
+        }
+
+        if(timeDiff/DateUtils.MINUTE_IN_MILLIS == 0){
+            timeResolution = DateUtils.SECOND_IN_MILLIS;
+        }else if(timeDiff/DateUtils.HOUR_IN_MILLIS == 0){
+            timeResolution = DateUtils.MINUTE_IN_MILLIS;
+        }else if(timeDiff/DateUtils.DAY_IN_MILLIS == 0){
+            timeResolution = DateUtils.HOUR_IN_MILLIS;
+        }else{
+            DateFormat df = new SimpleDateFormat("dd/MM/yyyy KK:mm aa");
+            Date date = (new Date(postTime));
+            return df.format(date);
+        }
+        return DateUtils.getRelativeTimeSpanString(postTime, currentTime, timeResolution).toString();
     }
+
     public void Close(View view) {
         finish();
     }

--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyListAdapter.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyListAdapter.java
@@ -124,7 +124,7 @@ public class ReplyListAdapter extends FirebaseListAdapter<Reply> {
         }else if(timeDiff/DateUtils.DAY_IN_MILLIS == 0){
             timeResolution = DateUtils.HOUR_IN_MILLIS;
         }else{
-            DateFormat df = new SimpleDateFormat("dd/MM/yyyy KK:mm aa");
+            DateFormat df = new SimpleDateFormat("yyyy/MM/dd KK:mm aa");
             Date date = (new Date(postTime));
             return df.format(date);
         }

--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyListAdapter.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyListAdapter.java
@@ -13,6 +13,8 @@ import com.firebase.client.Query;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -133,7 +135,15 @@ public class ReplyListAdapter extends FirebaseListAdapter<Reply> {
 
     @Override
     protected void sortModels(List<Reply> mModels) {
-
+        Collections.sort(mModels, new Comparator<Reply>(){
+            public int compare(Reply reply1, Reply reply2) {
+                if (reply1.getOrder() >= reply2.getOrder()) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyListAdapter.java
+++ b/app/src/main/java/hk/ust/cse/hunkim/questionroom/ReplyListAdapter.java
@@ -4,8 +4,8 @@ import android.app.Activity;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.text.Html;
+import android.text.format.DateUtils;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
@@ -107,12 +107,30 @@ public class ReplyListAdapter extends FirebaseListAdapter<Reply> {
         view.setTag(reply.getKey());  // store key in the view
     }
 
-    private String getDate(long timestamp)
+    //If you want to know more about the function, plz visit here http://developer.android.com/reference/android/text/format/DateUtils.html
+    private String getDate(long postTime)
     {
-        DateFormat df = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        Date date = (new Date(timestamp));
-        return df.format(date);
+        long currentTime = new Date().getTime();
+        long timeResolution = 0;
+        long timeDiff = currentTime-postTime;
+        if(timeDiff < DateUtils.SECOND_IN_MILLIS*5){
+            return "Just now";
+        }
+
+        if(timeDiff/DateUtils.MINUTE_IN_MILLIS == 0){
+            timeResolution = DateUtils.SECOND_IN_MILLIS;
+        }else if(timeDiff/DateUtils.HOUR_IN_MILLIS == 0){
+            timeResolution = DateUtils.MINUTE_IN_MILLIS;
+        }else if(timeDiff/DateUtils.DAY_IN_MILLIS == 0){
+            timeResolution = DateUtils.HOUR_IN_MILLIS;
+        }else{
+            DateFormat df = new SimpleDateFormat("dd/MM/yyyy KK:mm aa");
+            Date date = (new Date(postTime));
+            return df.format(date);
+        }
+        return DateUtils.getRelativeTimeSpanString(postTime, currentTime, timeResolution).toString();
     }
+
     @Override
     protected void sortModels(List<Reply> mModels) {
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">QuestionRoom</string>
+    <string name="app_name">resPOSTs</string>
     <string name="title_activity_login">Question Room</string>
 
     <!-- Strings related to login -->


### PR DESCRIPTION
The created time of both Questions and Replies are now displayed in another way.
- Posted within 5 seconds: "Just now"
- Posted within [5s,1mines): "x seconds ago"
- Posted within [1mines,1hour): "x minutes ago"
- Posted within [1hour,1day): "x hours ago"
- Posted within [1day , infinity): "yyyy/MM/dd KK:mm aa" (e.g, 2015/11/4 01:37 AM) Here I took reply 

Changed the apps name to resPOSTs

Implement sorts to replies only, sorted by "order" in descending order. (Currently havnt see the bug which duplicate and hide existing items) 
